### PR TITLE
Better handling for get_match_data requests that fail or wont finish loading

### DIFF
--- a/lolexport/export.py
+++ b/lolexport/export.py
@@ -57,8 +57,16 @@ def export_data(api_key: str, summoner_name: str, region: str) -> List[Dict[str,
     # attach lots of metadata to each match Dict response
     for i, m in enumerate(matches, 1):
         logger.debug(f"[{i}/{len(matches)}] Requesting match_id => {m}")
-        resp = get_match_data(lol_watcher, region, m)
-        # make sure were not overwriting some key from the API
+        # option to continue after a failed game
+        try:
+	    resp = get_match_data(lol_watcher, region, m)
+        except:
+            selection = input("Continue? [y/n]")
+            if selection.lower() == "y":
+                continue
+            break
+
+	# make sure were not overwriting some key from the API
         assert "gameId" not in resp
         resp["gameId"] = m
         data.append(resp)

--- a/lolexport/export.py
+++ b/lolexport/export.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Any
 
 from riotwatcher import LolWatcher, ApiError  # type: ignore[import]
 import backoff  # type: ignore[import]
+import click
 
 from .log import logger
 
@@ -59,12 +60,14 @@ def export_data(api_key: str, summoner_name: str, region: str) -> List[Dict[str,
         logger.debug(f"[{i}/{len(matches)}] Requesting match_id => {m}")
         # option to continue after a failed game
         try:
-	    resp = get_match_data(lol_watcher, region, m)
-        except:
-            selection = input("Continue? [y/n]")
-            if selection.lower() == "y":
+            resp = get_match_data(lol_watcher, region, m)
+        except (Exception, KeyboardInterrupt) as e:
+            if not isinstance(e, KeyboardInterrupt):
+                logger.exception(f"request failed: {e}")
+            if click.confirm("Continue requesting?", default=True):
                 continue
-            break
+            else:
+                break
 
 	# make sure were not overwriting some key from the API
         assert "gameId" not in resp


### PR DESCRIPTION
Wrapped the `get_match_data` Function in a try/catch block.

When an Exception occurs, such as an Interrupt with CTRL + C or some Statuscode Exception, the match in question is skipped and the user is given the option to continue with the next match or return all matches collected so far.